### PR TITLE
Oprava získavania playlistu streamovaného videa

### DIFF
--- a/resources/lib/markiza.py
+++ b/resources/lib/markiza.py
@@ -137,7 +137,7 @@ class MarkizaContentProvider(ContentProvider):
         result = []
         item = item.copy()
         video_id = urlparse(item['url']).path.split('/')[-1].split('_')[0]
-        videodata = util.json.loads(util.request('http://videoarchiv.markiza.sk/json/video_jwplayer7.json?is_web=1&id=' + video_id))
+        videodata = util.json.loads(util.request('http://videoarchiv.markiza.sk/json/video_jwplayer7.json?is_web=1&noads=1&nomidads=1&nopreads=1&nopostads=1&id=' + video_id))
         details = videodata['details']
         playlist = videodata['playlist']
         sources = [p['sources'][0]['file'] for p in playlist]


### PR DESCRIPTION
na webe videoarchiv.markiza.sk je už pomerne dávno pridaná podpora pre geoblocking a zobrazovanie reklám. Zmeny na webe spôsobili, že tento doplnok už dlhú dobu nefunguje. Pridaním pár parametrov *zatiaľ* dokážeme ignorovať podporu pre reklami a opäť prehrávať videá v Kodi.