### PR TITLE
1.2.1: Add option to choose quality

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="plugin.video.markiza.sk" name="markiza.sk" provider-name="Maros Ondrasek, refactoring: Peter Zaoral" version="1.2.0">
+<addon id="plugin.video.markiza.sk" name="markiza.sk" provider-name="Maros Ondrasek, refactoring: Peter Zaoral" version="1.2.1">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.module.stream.resolver" version="1.6.55" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+[B]1.2.1:[/B]
+- možnost vybrat kvalitu streamu
 [B]1.2.0:[/B]
 - oprava funkčnosti (změna webu)
 [B]1.1.9:[/B]

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
 	<string id="32000">Abecední řazení</string>
+	<string id="30050">Kvalita videa</string>
+	<string id="30051">Zeptat se</string>
+	<string id="30052">Nejlepší</string>
+	<string id="30053">Nejhorší</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
 	<string id="32000">Sort alphabetically</string>
+	<string id="30050">Video quality</string>
+    <string id="30051">Always ask</string>
+    <string id="30052">Best</string>
+    <string id="30053">Worst</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <strings>
 	<string id="32000">Abecedné triedenie</string>
+	<string id="30050">Kvalita videa</string>
+    <string id="30051">Spýtať sa</string>
+    <string id="30052">Najlepšia</string>
+    <string id="30053">Najhoršia</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings>
      <setting label="32000" id="sort" type="bool" default="true" />
+	 <setting label="30050" id="quality" type="enum" lvalues="30051|30052|30053" default="0" />
 </settings>


### PR DESCRIPTION
Možnost vybrat kvalitu streamu, momentálně se vybírá sama z manifest.m3u8. Tato oprava podle Enigma2 doplňku si vykuchá manifest.m3u8 na veškeré chunklisty (kvality) a nabízí seznam všech rozlišení, které jsou k dispozici. (Je možné vynutit určitou kvalitu v nastavení.)

Otestujte [zde.](https://github.com/koperfieldcz/plugin.video.markiza.sk/releases/download/1.2.1/plugin.video.markiza.sk-1.2.1-koperfield.zip)